### PR TITLE
Improve solver failure handling and surface user feedback

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -98,7 +98,14 @@ async def submit_job(req: JobRequest, background_tasks: BackgroundTasks):
 def job_status(job_id:str):
     if job_id not in jobs:
         raise HTTPException(404,"job not found")
-    return {"job_id":job_id,"status":jobs[job_id]["status"]}
+    payload = {"job_id": job_id, "status": jobs[job_id]["status"]}
+    if "error" in jobs[job_id]:
+        payload["error"] = jobs[job_id]["error"]
+    if "error_details" in jobs[job_id]:
+        payload["error_details"] = jobs[job_id]["error_details"]
+    if "warnings" in jobs[job_id]:
+        payload["warnings"] = jobs[job_id]["warnings"]
+    return payload
 
 @app.get("/results/{job_id}")
 def job_results(job_id:str):

--- a/backend/solvers/abstract_solver.py
+++ b/backend/solvers/abstract_solver.py
@@ -64,22 +64,6 @@ class AbstractSolver:
         raise NotImplementedError("Abstract method - implement in subclass")
 
 
-class SolverError(RuntimeError):
-    """Exception raised when a numerical solver cannot finish the integration."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        details: Optional[Dict[str, Any]] = None,
-        times: Optional[np.ndarray] = None,
-        trajectory: Optional[np.ndarray] = None,
-    ) -> None:
-        super().__init__(message)
-        self.details = details or {}
-        self.times = times
-        self.trajectory = trajectory
-
     def solve_batch(
         self,
         func: Callable[[float, np.ndarray, Dict[str, float]], np.ndarray],
@@ -103,3 +87,20 @@ class SolverError(RuntimeError):
                 times = t
             results.append(traj)
         return times, np.stack(results, axis=1)  # shape (nt, n_ic, ndim)
+
+
+class SolverError(RuntimeError):
+    """Exception raised when a numerical solver cannot finish the integration."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        times: Optional[np.ndarray] = None,
+        trajectory: Optional[np.ndarray] = None,
+    ) -> None:
+        super().__init__(message)
+        self.details = details or {}
+        self.times = times
+        self.trajectory = trajectory

--- a/backend/solvers/abstract_solver.py
+++ b/backend/solvers/abstract_solver.py
@@ -63,6 +63,23 @@ class AbstractSolver:
         """
         raise NotImplementedError("Abstract method - implement in subclass")
 
+
+class SolverError(RuntimeError):
+    """Exception raised when a numerical solver cannot finish the integration."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        times: Optional[np.ndarray] = None,
+        trajectory: Optional[np.ndarray] = None,
+    ) -> None:
+        super().__init__(message)
+        self.details = details or {}
+        self.times = times
+        self.trajectory = trajectory
+
     def solve_batch(
         self,
         func: Callable[[float, np.ndarray, Dict[str, float]], np.ndarray],

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -79,6 +79,9 @@ html,body,#root{height:100%;margin:0;padding:0;}
 .actions button[disabled]{opacity:0.5;cursor:not-allowed;background:#9bb7ff;}
 
 .status{font-size:0.9rem;color:var(--muted);}
+.status-error{margin-top:0.5rem;color:#c0392b;font-weight:500;}
+.status-warning{margin-top:0.5rem;padding-left:1.2rem;color:#f39c12;}
+.status-warning li{margin-bottom:0.25rem;}
 
 /* Visualization area */
 .visualization{


### PR DESCRIPTION
## Summary
- add a dedicated `SolverError` and translate SciPy failure messages into actionable guidance
- propagate solver errors to clients via structured status updates and expose details in the status API
- surface solver failures in the UI with dedicated messaging and styles

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68d5dc074a4c832db9d6bf0b58c02c96